### PR TITLE
Metadata tweaks

### DIFF
--- a/workshops/workshop_june_2024/newspaper-metadata.ipynb
+++ b/workshops/workshop_june_2024/newspaper-metadata.ipynb
@@ -48,6 +48,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from matplotlib import pyplot as plt\n",
+    "from pathlib import Path\n",
     "from tqdm import tqdm\n",
     "from dotenv import load_dotenv\n",
     "\n",
@@ -107,9 +108,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "titles_csv = \"./data/title_query_sorted.csv\"\n",
-    "issues_csv = \"./data/issue_query_sorted.csv\"\n",
-    "items_csv = \"./data/item_query_oa_sorted.csv\""
+    "titles_csv = Path(\"./data/title_query_sorted.csv\")\n",
+    "issues_csv = Path(\"./data/issue_query_sorted.csv\")\n",
+    "items_csv = Path(\"./data/item_query_oa_sorted.csv\")"
    ]
   },
   {
@@ -127,8 +128,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "issues_zip = \"./data/issue_query_sorted.zip\"\n",
-    "items_zip = \"./data/item_query_oa_sorted.zip\""
+    "issues_zip = Path(\"./data/issue_query_sorted.zip\")\n",
+    "items_zip = Path(\"./data/item_query_oa_sorted.zip\")"
    ]
   },
   {
@@ -177,7 +178,7 @@
    "source": [
     "all_files = [titles_csv, issues_csv, items_csv, issues_zip, items_zip]\n",
     "\n",
-    "if all(map(os.path.exists, all_files)):\n",
+    "if all(map(lambda file: file.exists(), all_files)):\n",
     "    print(\"All data files found. Skip forward to Section 3.\")\n",
     "else:\n",
     "    print(\"One or more data files were not found. Run the following cells to download data.\")"
@@ -310,7 +311,7 @@
    "outputs": [],
    "source": [
     "if not os.path.exists(titles_csv):\n",
-    "    path = f\"'https://opennewspapers.blob.core.windows.net/lwmdb/title_query_sorted.csv?{sas_token}'\"\n",
+    "    path = f\"'https://opennewspapers.blob.core.windows.net/lwmdb/{titles_csv.name}?{sas_token}'\"\n",
     "    !azcopy copy {path} {titles_csv}"
    ]
   },
@@ -330,10 +331,10 @@
    "outputs": [],
    "source": [
     "if not os.path.exists(issues_zip):\n",
-    "    path = f\"'https://opennewspapers.blob.core.windows.net/lwmdb/issue_query_sorted.zip?{sas_token}'\"\n",
+    "    path = f\"'https://opennewspapers.blob.core.windows.net/lwmdb/{issues_zip.name}?{sas_token}'\"\n",
     "    !azcopy copy {path} {issues_zip}\n",
     "if not os.path.exists (issues_csv):\n",
-    "    !unzip -j {issues_zip} -d \"./data\""
+    "    !unzip -j {issues_zip} -d {Path(\"data\")}"
    ]
   },
   {
@@ -352,10 +353,10 @@
    "outputs": [],
    "source": [
     "if not os.path.exists(items_zip):\n",
-    "    path = f\"'https://opennewspapers.blob.core.windows.net/lwmdb/{items_zip.split('/')[-1]}?{sas_token}'\"\n",
+    "    path = f\"'https://opennewspapers.blob.core.windows.net/lwmdb/{items_zip.name}?{sas_token}'\"\n",
     "    !azcopy copy {path} {items_zip}\n",
     "if not os.path.exists (items_csv):\n",
-    "    !unzip -j {items_zip} -d \"./data\""
+    "    !unzip -j {items_zip} -d {Path(\"data\")}"
    ]
   },
   {
@@ -1120,7 +1121,7 @@
     "\n",
     "# Gets the local relative path to the article full text (zip file) for a given publication.\n",
     "def fulltext_zip(publication_code):\n",
-    "    return f\"./data/{provider(publication_code)}-alto2txt/{publication_code}_plaintext.zip\"\n",
+    "    return Path(f\"./data/{provider(publication_code)}-alto2txt/{publication_code}_plaintext.zip\")\n",
     "\n",
     "# Returns the cloud storage location of the article full text (zip file) for a given publication.\n",
     "def fulltext_blob(publication_code):\n",
@@ -1212,7 +1213,7 @@
    "source": [
     "# Returns the path to the full text file, for a particular newspaper item, inside a zip archive.\n",
     "def item_path(item_code):\n",
-    "    return f\"{item_code[:7]}/{item_code[8:12]}/{item_code[12:16]}/{item_code.replace('-', '_')}.txt\"\n",
+    "    return Path(f\"{item_code[:7]}/{item_code[8:12]}/{item_code[12:16]}/{item_code.replace('-', '_')}.txt\")\n",
     "\n",
     "# Reads the full text for a given newspaper item.\n",
     "def read_item(item_code):\n",
@@ -1220,7 +1221,7 @@
     "    if not os.path.exists(fulltext_zip(pub_code)):\n",
     "        raise(FileNotFoundError(f\"Zip archive not found for publication {pub_code}. Use download_fulltext().\"))\n",
     "    with zipfile.ZipFile(fulltext_zip(pub_code)) as z:\n",
-    "        return z.read(item_path(item_code))\n",
+    "        return z.read(str(item_path(item_code)))\n",
     "\n",
     "# Returns a dictionary of newspaper item full text, keyed by the item_code.\n",
     "def read_items(items_sample):\n",
@@ -1325,7 +1326,7 @@
   "kernelspec": {
    "display_name": "htop",
    "language": "python",
-   "name": "python3"
+   "name": "htop"
   },
   "language_info": {
    "codemirror_mode": {

--- a/workshops/workshop_june_2024/newspaper-metadata.ipynb
+++ b/workshops/workshop_june_2024/newspaper-metadata.ipynb
@@ -258,7 +258,7 @@
     "# If the .env file does not exist, create it.\n",
     "else:\n",
     "    sas_token = input()\n",
-    "    !echo 'SAS_TOKEN=\"{sas_token}\"' >> .env"
+    "    !echo 'SAS_TOKEN=\"{sas_token}\"' > .env"
    ]
   },
   {


### PR DESCRIPTION
Tweaks for the metadata notebook:
 - overwrite the .env file (don't append)
 - use `pathlib` throughout for local file paths